### PR TITLE
UPSTREAM: <carry>: pin upper-constraints

### DIFF
--- a/openstack-ilib-tester.Dockerfile
+++ b/openstack-ilib-tester.Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 
+ENV TOX_CONSTRAINTS_FILE="https://releases.openstack.org/constraints/upper/2024.2"
+
 RUN dnf install -y python3-devel python3-pip \
  && dnf clean all \
  && rm -rf /var/cache/yum \


### PR DESCRIPTION
We need to pin libraries that are still compatible with python 3.9 as upstream has already dropped compatibility.

(cherry picked from commit afe8217cba1a510a481de7a28c5af4bc86af2de5)